### PR TITLE
Add a prerelease org definition

### DIFF
--- a/orgs/prerelease.json
+++ b/orgs/prerelease.json
@@ -1,0 +1,11 @@
+{
+  "edition": "Developer",
+  "orgName": "CumulusCI-Test Dev Workspace", 
+  "instance": "cs46",
+  "settings": {
+    "orgPreferenceSettings": {
+      "chatterEnabled": true,
+      "s1DesktopEnabled": true
+    }
+  }
+}


### PR DESCRIPTION
So that we can run CumulusCI tests this week. (I'm updating the CircleCI environment variables to use this org instead of dev.)