### PR TITLE
Update the package API version

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -3,7 +3,7 @@ project:
     package:
         name: CumulusCI Test
         namespace: ccitest
-        api_version: 46.0
+        api_version: 47.0
     git:
         repo_url: https://github.com/SalesforceFoundation/CumulusCI-Test
     dependencies:

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -7,5 +7,5 @@
   ],
   "namespace": "",
   "sfdcLoginUrl": "https://gs0.salesforce.com",
-  "sourceApiVersion": "46.0"
+  "sourceApiVersion": "47.0"
 }


### PR DESCRIPTION
This is especially important because the updated scratch org definition files don't work without it.

Fixes #183 