### PR TITLE
Use the default sfdxLoginUrl

### DIFF
--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -6,6 +6,5 @@
     }
   ],
   "namespace": "",
-  "sfdcLoginUrl": "https://gs0.salesforce.com",
   "sourceApiVersion": "47.0"
 }


### PR DESCRIPTION
I think gs0 was here from when sfdx was in beta. And it's not working this morning.