### PR TITLE
Testing CODEOWNERS behavior

### DIFF
--- a/tasks/example.py
+++ b/tasks/example.py
@@ -15,7 +15,7 @@ class StaticPreflightTask(BaseTask):
             "required": True,
         },
         "status_code": {
-            "description": 'Status code to return, default to "ok".',
+            "description": 'Status code to return, defaults to "ok"',
             "required": False,
         },
         "msg": {"description": "Message to be included", "required": False},


### PR DESCRIPTION
Minor edit to trigger codeowners, with the intention of verifying whether child teams can/cannot approve codeowners for the parent team.